### PR TITLE
Include full topic body in organizer serializer

### DIFF
--- a/controllers/topics_controller.rb
+++ b/controllers/topics_controller.rb
@@ -4,11 +4,13 @@ module WebkitComponents
 
     def relevant_records
       Topic.distinct
+           .listable_topics
            .secured(guardian)
            .includes(user: :user_profile)
            .left_outer_joins(:tags, :category)
            .yield_self { |r| params_for(:categories) ? r.where("categories.slug": params_for(:categories)) : r }
            .yield_self { |r| params_for(:tags) ? r.where("tags.name": params_for(:tags)) : r }
+           .yield_self { |r| params_for(:serializer).to_a.join == "organizer" ? r.left_outer_joins(:first_post) : r }
     end
   end
 end

--- a/serializers/organizer_serializer.rb
+++ b/serializers/organizer_serializer.rb
@@ -1,9 +1,13 @@
 module WebkitComponents
   class OrganizerSerializer < TopicSerializer
-    attribute :username
+    attributes :username, :cooked
 
     def username
       object.excerpt.to_s.match(/(@[^\s]*(?=<\/a>))/)
+    end
+
+    def cooked
+      object.first_post&.cooked
     end
 
     def include_views?

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -12,8 +12,10 @@ describe ::WebkitComponents::TopicsController do
   describe "index" do
     fab!(:event) { Fabricate(:topic) }
     fab!(:story) { Fabricate(:topic) }
+    fab!(:organizer) { Fabricate(:topic) }
     fab!(:festival_category) { Fabricate(:category, slug: :festival) }
     fab!(:conversation_category) { Fabricate(:category, slug: :conversation) }
+    fab!(:organizer_category) { Fabricate(:category, slug: :organizers) }
     fab!(:event_tag) { Fabricate(:tag, name: "webcontent-event") }
     fab!(:story_tag) { Fabricate(:tag, name: "webcontent-story") }
     fab!(:confirmed_tag) { Fabricate(:tag, name: "event-confirmed") }
@@ -24,6 +26,7 @@ describe ::WebkitComponents::TopicsController do
 
       event.update(category: festival_category)
       story.update(category: conversation_category)
+      organizer.update(category: organizer_category)
     end
 
     it "returns a topic for a single tag" do
@@ -60,6 +63,13 @@ describe ::WebkitComponents::TopicsController do
       event_json = response_json[0]
       expect(event_json['confirmed']).to eq true
       expect(event_json)
+    end
+
+    it "return the full topic body for organizers" do
+      organizer.posts << Fabricate(:post)
+      get :index, params: { serializer: "organizer" }, format: :json
+
+      expect(response_json.detect { |t| t['id'] == organizer.id }['cooked']).to eq organizer.first_post.cooked
     end
 
     it "uses the default serializer if an unknown serializer is passed" do


### PR DESCRIPTION
This includes the full topic's first body cooked value in the `OrganizerSerializer`, since this acts as the full bio for the organizer(s) in question.